### PR TITLE
fix : removed unnecessary generic Digest arguments

### DIFF
--- a/channel/src/fs_prover_channel.rs
+++ b/channel/src/fs_prover_channel.rs
@@ -100,14 +100,14 @@ impl<F: PrimeField, P: Prng> Channel for FSProverChannel<F, P> {
 }
 
 impl<F: PrimeField, P: Prng> FSChannel for FSProverChannel<F, P> {
-    type PowHash = P;
+    type PowHash = P::DigestType;
 
     fn apply_proof_of_work(&mut self, security_bits: usize) -> Result<(), anyhow::Error> {
         if security_bits == 0 {
             return Ok(());
         }
 
-        let worker = ProofOfWorkProver::<Self::FieldHash>::default();
+        let worker = ProofOfWorkProver::<Self::PowHash>::default();
         let pow = worker.prove(
             &self.prng.prng_state(),
             security_bits,

--- a/channel/src/fs_verifier_channel.rs
+++ b/channel/src/fs_verifier_channel.rs
@@ -103,16 +103,15 @@ impl<F: PrimeField, P: Prng> Channel for FSVerifierChannel<F, P> {
 }
 
 impl<F: PrimeField, P: Prng> FSChannel for FSVerifierChannel<F, P> {
-    type PowHash = P;
+    type PowHash = P::DigestType;
 
     fn apply_proof_of_work(&mut self, security_bits: usize) -> Result<(), anyhow::Error> {
         if security_bits == 0 {
             return Ok(());
         }
 
-        let worker: ProofOfWorkVerifier<Self::FieldHash> = Default::default();
-        let witness = self.recv_data(ProofOfWorkVerifier::<Self::FieldHash>::NONCE_BYTES)?;
-        // TODO : remove magic number ( thread count , log_chunk_size )
+        let worker: ProofOfWorkVerifier<Self::PowHash> = Default::default();
+        let witness = self.recv_data(ProofOfWorkVerifier::<Self::PowHash>::NONCE_BYTES)?;
 
         match worker.verify(self.proof.get_ref(), security_bits, &witness) {
             true => Ok(()),

--- a/channel/src/tests.rs
+++ b/channel/src/tests.rs
@@ -8,10 +8,9 @@ use hex_literal::hex;
 use randomness::{Prng, PrngKeccak256, PrngOnlyForTest};
 use sha3::digest::generic_array::GenericArray;
 use sha3::digest::OutputSizeUser;
-use sha3::Sha3_256;
 
-type MyFSVerifierChannel = FSVerifierChannel<Felt252, Sha3_256, PrngKeccak256>;
-type MyFSProverChannel = FSProverChannel<Felt252, Sha3_256, PrngKeccak256>;
+type MyFSVerifierChannel = FSVerifierChannel<Felt252, PrngKeccak256>;
+type MyFSProverChannel = FSProverChannel<Felt252, PrngKeccak256>;
 
 fn generate_commitment(
     prng: &mut PrngKeccak256,

--- a/randomness/src/lib.rs
+++ b/randomness/src/lib.rs
@@ -3,13 +3,18 @@ mod hash_chain;
 use crate::hash_chain::HashChain;
 use ark_ff::BigInteger;
 use ark_ff::PrimeField;
+use sha3::Digest;
 use std::collections::HashSet;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::vec::Vec;
 
+pub use sha3::Sha3_256;
+
 const INCREMENT_SEED: u64 = 1;
 
 pub trait Prng {
+    type DigestType: Digest;
+
     fn new() -> Self;
     fn new_with_seed(seed: &[u8]) -> Self;
 
@@ -21,7 +26,6 @@ pub trait Prng {
 }
 
 pub trait PrngOnlyForTest: Prng {
-    // TODO : implement numeric generic version e.g u8, u16, i32
     fn uniform_int(&mut self, range: std::ops::RangeInclusive<u64>) -> u64 {
         let (min, max) = (*range.start(), *range.end());
         assert!(min <= max, "Invalid interval");
@@ -94,6 +98,8 @@ pub struct PrngKeccak256 {
 
 // TODO : Implement Rng trait
 impl Prng for PrngKeccak256 {
+    type DigestType = Sha3_256;
+
     fn new() -> Self {
         let seed = [0u8; 32];
         PrngKeccak256 {
@@ -110,13 +116,6 @@ impl Prng for PrngKeccak256 {
     fn random_bytes(&mut self, random_bytes_out: &mut [u8]) {
         self.hash_chain.random_bytes(random_bytes_out);
     }
-
-    // template <typename OtherHashT>
-    // OtherHashT RandomHash() {
-    //   return OtherHashT::InitDigestTo(RandomByteVector(OtherHashT::kDigestNumBytes));
-    // }
-
-    // pub fn random_other_hash
 
     fn mix_seed_with_bytes(&mut self, raw_bytes: &[u8]) {
         self.hash_chain


### PR DESCRIPTION
* added associated types to Prng

- The second generic `Digest` is only for handling the types of `recv_commit_hash` or `send_commit_hash`. I eliminate this digest.